### PR TITLE
default input dir for graphs is "input"

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ Training a CapsGNN model is handled by the `src/main.py` script which provides t
 
 #### Input and output options
 ```
-  --training-graphs   STR    Training graphs folder.      Default is `dataset/train/`.
-  --testing-graphs    STR    Testing graphs folder.       Default is `dataset/test/`.
+  --training-graphs   STR    Training graphs folder.      Default is `input/train/`.
+  --testing-graphs    STR    Testing graphs folder.       Default is `input/test/`.
   --prediction-path   STR    Output predictions file.     Default is `output/watts_predictions.csv`.
 ```
 #### Model options


### PR DESCRIPTION
The README mentions the default train and test graphs to be in dataset/train and dataset/test, whereas they are in input/train and input/test respectively. The param_parser.py has the correct default paths nevertheless.